### PR TITLE
[P3] Input Field component (ID-3169)

### DIFF
--- a/.specs/features/p3-input-field/spec.md
+++ b/.specs/features/p3-input-field/spec.md
@@ -1,0 +1,123 @@
+# Input Field — P3 Spec (ID-3169)
+
+**Figma source:** Star System DS · fileKey `6wfkhBhONJ7r4A0PZWIsIs` · nodeId `3206:12256`  
+**Verified nodes:** `3216:9794` (placeholder), `3216:9842` (filled), `3216:9844` (error), `3216:9824` (disabled), `3216:9802` (label), `3216:9812` (label+hint), `3216:9574` (leading icon)
+
+---
+
+## Component
+
+`Input` — controlled text input with floating label, hint/error text, and optional icon slots.
+
+**File path:** `src/components/Input/`
+
+---
+
+## Figma-Verified Tokens
+
+### Container
+
+| Property | Value | Token |
+|---|---|---|
+| Background (default/error) | `#F7F7F7` | Neutral/25 |
+| Background (disabled) | `#EFEFEF` | Neutral/50 |
+| Border (default) | `#B6B6B6` | Neutral/300 |
+| Border (error) | `#FF4242` | Support/Error/Base |
+| Border radius | `16px` | |
+| Padding | `px-[16px] py-[8px]` | |
+| Inner height | `h-[40px]` | label-input area |
+| Gap (icon ↔ text) | `gap-[8px]` | |
+| Shadow (default/error) | `0px 1px 2px 0px rgba(12,17,29,0.10)` | Elevation/00 |
+| Shadow (disabled) | none | |
+
+### Typography
+
+| Element | Size | Line height | Letter spacing | Color | Token |
+|---|---|---|---|---|---|
+| Label (floating) | 12px | 16px | 0 | `#9C9C9C` | Neutral/400, Caption/Regular |
+| Input value | 16px | 24px | 0 | `#393939` | Neutral/800, Subtitle/MD/Regular |
+| Placeholder (no label) | 16px | 24px | 0 | `#9C9C9C` | Neutral/400 |
+| Placeholder (with label) | 16px | 24px | 0 | `#808080` | Neutral/500 |
+| Input text (disabled) | 16px | 24px | 0 | `#B6B6B6` | Neutral/300 |
+| Hint text | 14px | 20px | 0.1px | `#808080` | Neutral/500, Subtitle/SM/Regular |
+| Error text | 14px | 20px | 0.1px | `#FF4242` | Support/Error/Base |
+
+Font family: `Funnel Display` (all elements)
+
+### Icon slots
+
+| Property | Value |
+|---|---|
+| Icon size | `24px × 24px` |
+| Icon color (neutral) | `#808080` (Neutral/500) |
+| Gap below input → hint | `6px` |
+
+### Focus state (inferred — not in Figma)
+
+`focus-within:ring-2 focus-within:ring-[#FF5100] focus-within:ring-offset-2` — brand primary, same pattern as Button.
+
+---
+
+## States
+
+| State | bg | border | shadow | input text | placeholder |
+|---|---|---|---|---|---|
+| Placeholder (default) | `#F7F7F7` | `#B6B6B6` | yes | — | `#9C9C9C` |
+| Filled | `#F7F7F7` | `#B6B6B6` | yes | `#393939` | — |
+| Error | `#F7F7F7` | `#FF4242` | yes | `#393939` | — |
+| Disabled | `#EFEFEF` | `#B6B6B6` | no | `#B6B6B6` | `#B6B6B6` |
+
+---
+
+## Props API
+
+```tsx
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string       // floating label inside container (12px, Neutral/400)
+  hint?: string        // helper text below container (14px, Neutral/500)
+  error?: string       // error message below; also sets error border; overrides hint
+  leadingIcon?: ReactNode
+  trailingIcon?: ReactNode
+}
+```
+
+- Extends `InputHTMLAttributes<HTMLInputElement>` — passthrough `disabled`, `id`, `onChange`, `value`, `placeholder`, `type`, `aria-*`, etc.
+- `error` takes precedence over `hint` for the text below.
+- When `error` is set, border → `#FF4242`; hint text → `#FF4242`.
+- `disabled` from HTML attrs: bg → `#EFEFEF`, text → `#B6B6B6`, `cursor-not-allowed`, no shadow.
+- `label` renders as a `<span>` inside the container above the `<input>`.
+
+---
+
+## Accessibility
+
+- Wrap outer `<div>` is not the label target — the inner `<input>` must have `id` forwarded.
+- When `label` prop is set, render `<label htmlFor={id}>` if `id` is provided; else use `aria-label` fallback.
+- Error state: `aria-invalid="true"` on `<input>`, `aria-describedby` pointing to error text `<p>`.
+- Hint state: `aria-describedby` pointing to hint text `<p>`.
+- `disabled`: HTML `disabled` attr on `<input>`.
+
+---
+
+## Anatomy
+
+```
+<div> (wrapper — flex col gap-[6px])
+  <div> (container — bg, border, rounded-[16px], shadow, px-[16px] py-[8px], flex row gap-[8px])
+    [leadingIcon? → <span> size-[24px]]
+    <div> (label-input — flex col h-[40px] justify-center flex-1 min-w-0)
+      [label? → <span> 12px #9C9C9C]
+      <input> (16px Funnel Display, bg-transparent)
+    [trailingIcon? → <span> size-[24px]]
+  [hint|error? → <p> 14px]
+```
+
+---
+
+## Not in scope (P3)
+
+- `Type=Leading dropdown`, `Type=Trailing dropdown`, `Type=Leading text`, `Type=Payment input` — deferred
+- `Textarea` input — separate component
+- `Verification code` input — separate component
+- `Input Increment` — separate component
+- Multiple sizes (Figma shows single outline size for this component)

--- a/.specs/features/p3-input-field/tasks.md
+++ b/.specs/features/p3-input-field/tasks.md
@@ -1,0 +1,422 @@
+# Input Field P3 — Implementation Tasks
+
+> **For agentic workers:** use `superpowers:subagent-driven-development` or `superpowers:executing-plans`.
+
+**Goal:** Implement `Input` component per spec (ID-3169) — floating label, hint/error text, leading/trailing icon slots, disabled state, a11y, stories, tests.
+
+**Architecture:** Single `Input.tsx`. Wraps a native `<input>` element. Uses `cn()` + Tailwind CSS v4 hardcoded hex tokens from Figma. No new dependencies.
+
+**Tech Stack:** React 18, TypeScript strict, Tailwind CSS v4, Vite lib mode, vitest + @testing-library/react, Storybook 8.
+
+## Global Constraints
+
+- Tailwind v4: no `tailwind.config.js` — tokens in `src/styles/globals.css` `@theme {}`. Use direct hex when needed.
+- `cn()` at `src/utils/cn.ts`. Always use for class merging.
+- ESM only.
+- Export `Input` and `InputProps` from `src/components/Input/index.ts` AND `src/index.ts`.
+- Run `pnpm typecheck && pnpm test` after each task to gate.
+- Branch: `feat/ID-3169-input-field`
+
+---
+
+### Task 1: Implement Input component
+
+**Files:**
+- Create: `src/components/Input/Input.tsx`
+
+**Interfaces:**
+- Consumes: `src/utils/cn.ts` → `cn()`
+- Produces: `Input`, `InputProps` (used by Tasks 2, 3, 4)
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+import { type InputHTMLAttributes, type ReactNode } from 'react'
+import { cn } from '../../utils/cn'
+
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  label?: string
+  hint?: string
+  error?: string
+  leadingIcon?: ReactNode
+  trailingIcon?: ReactNode
+}
+
+export function Input({
+  label,
+  hint,
+  error,
+  leadingIcon,
+  trailingIcon,
+  className,
+  disabled,
+  id,
+  ...props
+}: InputProps) {
+  const isError = Boolean(error)
+  const hintText = error ?? hint
+  const hintId = hintText && id ? `${id}-hint` : undefined
+
+  return (
+    <div className={cn('flex flex-col gap-[6px] items-start w-full', className)}>
+      <div
+        className={cn(
+          'flex gap-[8px] items-center overflow-hidden px-[16px] py-[8px] rounded-[16px] w-full border',
+          'focus-within:outline-none focus-within:ring-2 focus-within:ring-[#FF5100] focus-within:ring-offset-2',
+          disabled
+            ? 'bg-[#EFEFEF] border-[#B6B6B6] cursor-not-allowed'
+            : isError
+              ? 'bg-[#F7F7F7] border-[#FF4242] shadow-[0px_1px_2px_0px_rgba(12,17,29,0.10)]'
+              : 'bg-[#F7F7F7] border-[#B6B6B6] shadow-[0px_1px_2px_0px_rgba(12,17,29,0.10)]',
+        )}
+      >
+        {leadingIcon && (
+          <span className="shrink-0 size-[24px] flex items-center justify-center text-[#808080]">
+            {leadingIcon}
+          </span>
+        )}
+        <div className="flex flex-col flex-1 min-w-0 h-[40px] justify-center">
+          {label && (
+            <span className="font-['Funnel_Display'] text-[12px] leading-[16px] text-[#9C9C9C] shrink-0 select-none">
+              {label}
+            </span>
+          )}
+          <input
+            id={id}
+            disabled={disabled}
+            aria-invalid={isError || undefined}
+            aria-describedby={hintId}
+            className={cn(
+              "bg-transparent outline-none font-['Funnel_Display'] text-[16px] leading-[24px] w-full",
+              disabled
+                ? 'text-[#B6B6B6] cursor-not-allowed placeholder:text-[#B6B6B6]'
+                : label
+                  ? 'text-[#393939] placeholder:text-[#808080]'
+                  : 'text-[#393939] placeholder:text-[#9C9C9C]',
+            )}
+            {...props}
+          />
+        </div>
+        {trailingIcon && (
+          <span className="shrink-0 size-[24px] flex items-center justify-center text-[#808080]">
+            {trailingIcon}
+          </span>
+        )}
+      </div>
+      {hintText && (
+        <p
+          id={hintId}
+          className={cn(
+            "font-['Funnel_Display'] text-[14px] leading-[20px] tracking-[0.1px] w-full",
+            isError ? 'text-[#FF4242]' : 'text-[#808080]',
+          )}
+        >
+          {hintText}
+        </p>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Verify typecheck passes**
+
+Run: `pnpm typecheck`
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/Input/Input.tsx
+git commit -m "feat(input): implement Input component with Figma-verified tokens"
+```
+
+---
+
+### Task 2: Create index.ts and update barrel export
+
+**Files:**
+- Create: `src/components/Input/index.ts`
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Create component index**
+
+`src/components/Input/index.ts`:
+```ts
+export { Input } from './Input'
+export type { InputProps } from './Input'
+```
+
+- [ ] **Step 2: Add to library barrel**
+
+In `src/index.ts`, add after Button exports:
+```ts
+export { Input } from './components/Input'
+export type { InputProps } from './components/Input'
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: no errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/Input/index.ts src/index.ts
+git commit -m "feat(input): update barrel exports"
+```
+
+---
+
+### Task 3: Write Input tests
+
+**Files:**
+- Create: `src/components/Input/Input.test.tsx`
+
+**Depends on:** Task 1
+
+- [ ] **Step 1: Write tests**
+
+```tsx
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { Input } from './Input'
+
+describe('Input', () => {
+  it('renders an input element', () => {
+    render(<Input />)
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
+  })
+
+  it('forwards placeholder', () => {
+    render(<Input placeholder="Enter email" />)
+    expect(screen.getByPlaceholderText('Enter email')).toBeInTheDocument()
+  })
+
+  it('renders label when provided', () => {
+    render(<Input label="Email" />)
+    expect(screen.getByText('Email')).toBeInTheDocument()
+  })
+
+  it('renders hint text when provided', () => {
+    render(<Input hint="This is a hint" />)
+    expect(screen.getByText('This is a hint')).toBeInTheDocument()
+  })
+
+  it('renders error text when provided', () => {
+    render(<Input id="email" error="Invalid email" />)
+    expect(screen.getByText('Invalid email')).toBeInTheDocument()
+  })
+
+  it('error overrides hint', () => {
+    render(<Input hint="Hint text" error="Error text" />)
+    expect(screen.getByText('Error text')).toBeInTheDocument()
+    expect(screen.queryByText('Hint text')).not.toBeInTheDocument()
+  })
+
+  it('sets aria-invalid when error is provided', () => {
+    render(<Input id="email" error="Invalid email" />)
+    expect(screen.getByRole('textbox')).toHaveAttribute('aria-invalid', 'true')
+  })
+
+  it('links aria-describedby to hint element when id provided', () => {
+    render(<Input id="email" hint="Hint text" />)
+    const input = screen.getByRole('textbox')
+    const hint = screen.getByText('Hint text')
+    expect(input).toHaveAttribute('aria-describedby', 'email-hint')
+    expect(hint).toHaveAttribute('id', 'email-hint')
+  })
+
+  it('is disabled when disabled prop set', () => {
+    render(<Input disabled />)
+    expect(screen.getByRole('textbox')).toBeDisabled()
+  })
+
+  it('does not fire onChange when disabled', async () => {
+    const handler = vi.fn()
+    render(<Input disabled onChange={handler} />)
+    await userEvent.type(screen.getByRole('textbox'), 'hello')
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('fires onChange when enabled', async () => {
+    const handler = vi.fn()
+    render(<Input onChange={handler} />)
+    await userEvent.type(screen.getByRole('textbox'), 'a')
+    expect(handler).toHaveBeenCalled()
+  })
+
+  it('renders leadingIcon', () => {
+    render(<Input leadingIcon={<span data-testid="leading-icon" />} />)
+    expect(screen.getByTestId('leading-icon')).toBeInTheDocument()
+  })
+
+  it('renders trailingIcon', () => {
+    render(<Input trailingIcon={<span data-testid="trailing-icon" />} />)
+    expect(screen.getByTestId('trailing-icon')).toBeInTheDocument()
+  })
+
+  it('forwards id to input element', () => {
+    render(<Input id="my-input" />)
+    expect(screen.getByRole('textbox')).toHaveAttribute('id', 'my-input')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `pnpm test -- src/components/Input/Input.test.tsx`
+Expected: all pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/Input/Input.test.tsx
+git commit -m "test(input): comprehensive Input tests (states, a11y, icons)"
+```
+
+---
+
+### Task 4: Write Storybook stories
+
+**Files:**
+- Create: `src/components/Input/Input.stories.tsx`
+
+**Depends on:** Task 1
+
+- [ ] **Step 1: Write stories**
+
+```tsx
+import type { Meta, StoryObj } from '@storybook/react'
+import { Input } from './Input'
+
+const meta: Meta<typeof Input> = {
+  title: 'Components/Input',
+  component: Input,
+  tags: ['autodocs'],
+  args: {
+    placeholder: 'Enter value',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof Input>
+
+export const Default: Story = {}
+
+export const WithLabel: Story = {
+  args: {
+    label: 'Email',
+    placeholder: 'olivia@untitledui.com',
+    id: 'email-with-label',
+  },
+}
+
+export const WithHint: Story = {
+  args: {
+    label: 'Email',
+    placeholder: 'olivia@untitledui.com',
+    hint: 'This is a hint text to help user.',
+    id: 'email-with-hint',
+  },
+}
+
+export const WithError: Story = {
+  args: {
+    label: 'Email',
+    placeholder: 'olivia@untitledui.com',
+    error: 'This email is already taken.',
+    id: 'email-with-error',
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    label: 'Email',
+    placeholder: 'olivia@untitledui.com',
+    disabled: true,
+  },
+}
+
+export const WithLeadingIcon: Story = {
+  args: {
+    label: 'Email',
+    placeholder: 'olivia@untitledui.com',
+    leadingIcon: (
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+        <polyline points="22,6 12,13 2,6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+      </svg>
+    ),
+  },
+}
+
+export const WithTrailingIcon: Story = {
+  args: {
+    placeholder: 'Search...',
+    trailingIcon: (
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="11" cy="11" r="8" stroke="currentColor" strokeWidth="2"/>
+        <path d="m21 21-4.35-4.35" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+      </svg>
+    ),
+  },
+}
+
+export const NoLabel: Story = {
+  args: {
+    placeholder: 'Email address',
+  },
+}
+
+export const AllStates: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6 p-4 max-w-sm">
+      <Input placeholder="Placeholder (no label)" />
+      <Input label="Email" placeholder="olivia@untitledui.com" />
+      <Input label="Email" placeholder="olivia@untitledui.com" hint="This is a hint text." id="all-hint" />
+      <Input label="Email" placeholder="olivia@untitledui.com" error="This email is already taken." id="all-error" />
+      <Input label="Email" placeholder="olivia@untitledui.com" disabled />
+    </div>
+  ),
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/Input/Input.stories.tsx
+git commit -m "docs(input): Storybook stories — all states, icons, label/hint/error"
+```
+
+---
+
+### Task 5: Build verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `pnpm test`
+Expected: all tests pass (Button + Input)
+
+- [ ] **Step 2: Build library**
+
+Run: `pnpm build`
+Expected: `dist/index.js` and `dist/style.css` with no errors
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: no errors
+
+- [ ] **Step 4: Git status check**
+
+```bash
+git status
+```

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Input } from './Input'
+
+const meta: Meta<typeof Input> = {
+  title: 'Components/Input',
+  component: Input,
+  tags: ['autodocs'],
+  args: {
+    placeholder: 'Enter value',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof Input>
+
+export const Default: Story = {}
+
+export const WithLabel: Story = {
+  args: {
+    label: 'Email',
+    placeholder: 'olivia@untitledui.com',
+    id: 'email-with-label',
+  },
+}
+
+export const WithHint: Story = {
+  args: {
+    label: 'Email',
+    placeholder: 'olivia@untitledui.com',
+    hint: 'This is a hint text to help user.',
+    id: 'email-with-hint',
+  },
+}
+
+export const WithError: Story = {
+  args: {
+    label: 'Email',
+    placeholder: 'olivia@untitledui.com',
+    error: 'This email is already taken.',
+    id: 'email-with-error',
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    label: 'Email',
+    placeholder: 'olivia@untitledui.com',
+    disabled: true,
+  },
+}
+
+export const WithLeadingIcon: Story = {
+  args: {
+    label: 'Email',
+    placeholder: 'olivia@untitledui.com',
+    leadingIcon: (
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+        <polyline points="22,6 12,13 2,6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+      </svg>
+    ),
+  },
+}
+
+export const WithTrailingIcon: Story = {
+  args: {
+    placeholder: 'Search...',
+    trailingIcon: (
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="11" cy="11" r="8" stroke="currentColor" strokeWidth="2"/>
+        <path d="m21 21-4.35-4.35" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+      </svg>
+    ),
+  },
+}
+
+export const NoLabel: Story = {
+  args: {
+    placeholder: 'Email address',
+  },
+}
+
+export const AllStates: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6 p-4 max-w-sm">
+      <Input placeholder="Placeholder (no label)" />
+      <Input label="Email" placeholder="olivia@untitledui.com" />
+      <Input label="Email" placeholder="olivia@untitledui.com" hint="This is a hint text." id="all-hint" />
+      <Input label="Email" placeholder="olivia@untitledui.com" error="This email is already taken." id="all-error" />
+      <Input label="Email" placeholder="olivia@untitledui.com" disabled />
+    </div>
+  ),
+}

--- a/src/components/Input/Input.test.tsx
+++ b/src/components/Input/Input.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { Input } from './Input'
+
+describe('Input', () => {
+  it('renders an input element', () => {
+    render(<Input />)
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
+  })
+
+  it('forwards placeholder', () => {
+    render(<Input placeholder="Enter email" />)
+    expect(screen.getByPlaceholderText('Enter email')).toBeInTheDocument()
+  })
+
+  it('renders label when provided', () => {
+    render(<Input label="Email" />)
+    expect(screen.getByText('Email')).toBeInTheDocument()
+  })
+
+  it('renders hint text when provided', () => {
+    render(<Input hint="This is a hint" />)
+    expect(screen.getByText('This is a hint')).toBeInTheDocument()
+  })
+
+  it('renders error text when provided', () => {
+    render(<Input id="email" error="Invalid email" />)
+    expect(screen.getByText('Invalid email')).toBeInTheDocument()
+  })
+
+  it('error overrides hint', () => {
+    render(<Input hint="Hint text" error="Error text" />)
+    expect(screen.getByText('Error text')).toBeInTheDocument()
+    expect(screen.queryByText('Hint text')).not.toBeInTheDocument()
+  })
+
+  it('sets aria-invalid when error is provided', () => {
+    render(<Input id="email" error="Invalid email" />)
+    expect(screen.getByRole('textbox')).toHaveAttribute('aria-invalid', 'true')
+  })
+
+  it('links aria-describedby to hint element when id provided', () => {
+    render(<Input id="email" hint="Hint text" />)
+    const input = screen.getByRole('textbox')
+    const hint = screen.getByText('Hint text')
+    expect(input).toHaveAttribute('aria-describedby', 'email-hint')
+    expect(hint).toHaveAttribute('id', 'email-hint')
+  })
+
+  it('is disabled when disabled prop set', () => {
+    render(<Input disabled />)
+    expect(screen.getByRole('textbox')).toBeDisabled()
+  })
+
+  it('does not fire onChange when disabled', async () => {
+    const handler = vi.fn()
+    render(<Input disabled onChange={handler} />)
+    await userEvent.type(screen.getByRole('textbox'), 'hello')
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('fires onChange when enabled', async () => {
+    const handler = vi.fn()
+    render(<Input onChange={handler} />)
+    await userEvent.type(screen.getByRole('textbox'), 'a')
+    expect(handler).toHaveBeenCalled()
+  })
+
+  it('renders leadingIcon', () => {
+    render(<Input leadingIcon={<span data-testid="leading-icon" />} />)
+    expect(screen.getByTestId('leading-icon')).toBeInTheDocument()
+  })
+
+  it('renders trailingIcon', () => {
+    render(<Input trailingIcon={<span data-testid="trailing-icon" />} />)
+    expect(screen.getByTestId('trailing-icon')).toBeInTheDocument()
+  })
+
+  it('forwards id to input element', () => {
+    render(<Input id="my-input" />)
+    expect(screen.getByRole('textbox')).toHaveAttribute('id', 'my-input')
+  })
+})

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,0 +1,86 @@
+import { type InputHTMLAttributes, type ReactNode } from 'react'
+import { cn } from '../../utils/cn'
+
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  label?: string
+  hint?: string
+  error?: string
+  leadingIcon?: ReactNode
+  trailingIcon?: ReactNode
+}
+
+export function Input({
+  label,
+  hint,
+  error,
+  leadingIcon,
+  trailingIcon,
+  className,
+  disabled,
+  id,
+  ...props
+}: InputProps) {
+  const isError = Boolean(error)
+  const hintText = error ?? hint
+  const hintId = hintText && id ? `${id}-hint` : undefined
+
+  return (
+    <div className={cn('flex flex-col gap-[6px] items-start w-full', className)}>
+      <div
+        className={cn(
+          'flex gap-[8px] items-center overflow-hidden px-[16px] py-[8px] rounded-[16px] w-full border',
+          'focus-within:outline-none focus-within:ring-2 focus-within:ring-[#FF5100] focus-within:ring-offset-2',
+          disabled
+            ? 'bg-[#EFEFEF] border-[#B6B6B6] cursor-not-allowed'
+            : isError
+              ? 'bg-[#F7F7F7] border-[#FF4242] shadow-[0px_1px_2px_0px_rgba(12,17,29,0.10)]'
+              : 'bg-[#F7F7F7] border-[#B6B6B6] shadow-[0px_1px_2px_0px_rgba(12,17,29,0.10)]',
+        )}
+      >
+        {leadingIcon && (
+          <span className="shrink-0 size-[24px] flex items-center justify-center text-[#808080]">
+            {leadingIcon}
+          </span>
+        )}
+        <div className="flex flex-col flex-1 min-w-0 h-[40px] justify-center">
+          {label && (
+            <span className="font-['Funnel_Display'] text-[12px] leading-[16px] text-[#9C9C9C] shrink-0 select-none">
+              {label}
+            </span>
+          )}
+          <input
+            id={id}
+            disabled={disabled}
+            aria-invalid={isError || undefined}
+            aria-describedby={hintId}
+            className={cn(
+              "bg-transparent outline-none font-['Funnel_Display'] text-[16px] leading-[24px] w-full",
+              disabled
+                ? 'text-[#B6B6B6] cursor-not-allowed placeholder:text-[#B6B6B6]'
+                : label
+                  ? 'text-[#393939] placeholder:text-[#808080]'
+                  : 'text-[#393939] placeholder:text-[#9C9C9C]',
+            )}
+            {...props}
+          />
+        </div>
+        {trailingIcon && (
+          <span className="shrink-0 size-[24px] flex items-center justify-center text-[#808080]">
+            {trailingIcon}
+          </span>
+        )}
+      </div>
+      {hintText && (
+        <p
+          id={hintId}
+          className={cn(
+            "font-['Funnel_Display'] text-[14px] leading-[20px] tracking-[0.1px] w-full",
+            isError ? 'text-[#FF4242]' : 'text-[#808080]',
+          )}
+        >
+          {hintText}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/Input/index.ts
+++ b/src/components/Input/index.ts
@@ -1,0 +1,2 @@
+export { Input } from './Input'
+export type { InputProps } from './Input'

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,9 @@ import './styles/globals.css'
 export { Button } from './components/Button'
 export type { ButtonProps } from './components/Button'
 
+export { Input } from './components/Input'
+export type { InputProps } from './components/Input'
+
 // Design tokens
 export { colors } from './tokens/colors'
 export type { Colors } from './tokens/colors'


### PR DESCRIPTION
## Summary

- Implements `Input` component with Figma-verified tokens from Star System DS (nodeId `3206:12256`)
- Floating label pattern: 12px label + 16px input coexist in `h-[40px]` container
- Props: `label`, `hint`, `error`, `leadingIcon`, `trailingIcon` + full `InputHTMLAttributes` passthrough
- States: default, error (`border-[#FF4242]`), disabled (`bg-[#EFEFEF]`, `cursor-not-allowed`)
- Accessibility: `aria-invalid`, `aria-describedby` linked to hint/error via `${id}-hint`
- Focus ring: `focus-within:ring-2 focus-within:ring-[#FF5100]` (brand primary)

## Files

| File | Description |
|---|---|
| `src/components/Input/Input.tsx` | Component implementation |
| `src/components/Input/index.ts` | Re-exports |
| `src/components/Input/Input.test.tsx` | 14 vitest tests |
| `src/components/Input/Input.stories.tsx` | 8 Storybook stories (autodocs) |
| `src/index.ts` | Barrel updated |
| `.specs/features/p3-input-field/spec.md` | Figma-verified spec |
| `.specs/features/p3-input-field/tasks.md` | Implementation tasks |

## Test plan

- [x] `pnpm test` — 45/45 passing (Button + Input + tokens)
- [x] `pnpm build` — dist/index.js + dist/style.css, no errors
- [x] `pnpm typecheck` — no errors
- [ ] Storybook: `pnpm storybook` → verify all 8 stories render correctly
- [ ] Visual check: Default, WithLabel, WithHint, WithError, Disabled states
- [ ] A11y: tab navigation, focus ring visible, screen reader (aria-invalid + aria-describedby)

## Jira

Parent: [ID-3169](https://starbemapp.atlassian.net/browse/ID-3169)
Subtasks: ID-3216 → ID-3220 (all QA Testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ID-3169]: https://starbemapp.atlassian.net/browse/ID-3169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ