### PR TITLE
feat(radio): Radio + RadioGroup component

### DIFF
--- a/.specs/features/p7-radio/spec.md
+++ b/.specs/features/p7-radio/spec.md
@@ -1,0 +1,98 @@
+# Radio Component Spec — P7
+
+**Jira:** ID-3173
+**Figma:** Star System → Checkboxes page (fileKey: `6wfkhBhONJ7r4A0PZWIsIs`, nodeId: `3228:15912` — Radio variants live on the same page/frame as Checkbox)
+**Branch:** `feat/ID-3173-radio`
+
+**Architecture decision:** Custom, not Radix UI — same decision and rationale as `Checkbox` (see `.specs/features/p6-checkbox/spec.md` Architecture decision). Already validated with the user for all remaining Radix-mentioning tasks.
+
+---
+
+## Figma-Verified Nodes
+
+| Node | Description |
+|---|---|
+| `3228:16330` / `3228:16282` | Radio, md, unchecked, Default (bare, 24px — two duplicate refs, same values) |
+| `3228:16345` / `3228:16250` | Radio, md, checked, Default |
+| `3228:16339` / `3228:16258` | Radio, md, unchecked, Hover |
+| `3228:16369` / `3228:16238` | Radio, md, checked, Hover |
+| `3228:16333` / `3228:16274` | Radio, md, unchecked, Disabled |
+| `3228:16353` / `3228:16226` | Radio, md, checked, Disabled |
+| `3228:16006` | Radio + label + supporting text, md, checked, Default (344px row anatomy — identical layout to Checkbox's) |
+
+## Requirements
+
+### R-01: Box anatomy
+
+Same two sizes as Checkbox, but fully round (`rounded-full` — Figma reports `rounded-[16px]` on a 24px box, which is geometrically a full circle):
+
+| Size | Outer circle | Inner dot (checked) |
+|---|---|---|
+| `sm` | 16×16px | ~8px — **[Provável]**, see note |
+| `md` (default) | 24×24px | ~12px — **[Provável]**, see note |
+
+> **[Provável]** Inner dot size: the Figma checked-radio node renders as a single flattened image (composited vector group), not exposed as separate border+fill layers via the design-context API. Visual inspection (pixel-upscaled screenshot of node `3228:16345`) shows a solid center dot roughly 40–50% of the box diameter. Used a clean 50% ratio (dot = box/2, centered). Validate against Figma directly if pixel-perfect match matters.
+
+### R-02: States & colors (Figma-verified for ring/background; dot color inferred from Checkbox's identical icon-color convention)
+
+| State | Background | Ring border | Dot color | Extra |
+|---|---|---|---|---|
+| Unchecked, Default | `#F7F7F7` (Neutral/25) | `#B6B6B6` (Neutral/300) | — | — |
+| Checked, Default | `#F7F7F7` | `#FF5100` (Primary/Base) | `#FF5100` | — |
+| Any, Hover | `#F7F7F7` | `#FF5100` | `#FF5100` if checked | glow shadow `0px 0px 12px 0px rgba(255,169,71,0.4)` (Elevation/Hover/Secondary) — identical to Checkbox's hover glow |
+| Unchecked, Disabled | `#E2E2E2` (Neutral/100) | `#CFCFCF` (Neutral/200) | — | cursor-not-allowed |
+| Checked, Disabled | `#E2E2E2` | `#CFCFCF` | `#CFCFCF` **[Provável]** | cursor-not-allowed — same inference as Checkbox's disabled icon color (no explicit color style surfaced by Figma for this state) |
+
+No indeterminate state (radios don't have one) and no error state (same as Checkbox — not in Figma).
+
+### R-03: Label + supporting text anatomy
+
+Identical to Checkbox's R-04 (same 344px row Figma component, same spacing/typography/weight-on-active convention): `flex items-start gap-[12px]`, `pt-[2px]` wrapper, label 16px/24px `#393939` (Regular unchecked → Medium checked), supporting text 14px/20px `#808080`.
+
+### R-04: Props API
+
+```ts
+export interface RadioProps {
+  value: string
+  checked?: boolean
+  disabled?: boolean
+  label?: string
+  supportingText?: string
+  size?: 'sm' | 'md'
+  id?: string
+  name?: string
+  className?: string
+}
+
+export interface RadioGroupProps {
+  children: ReactNode
+  value?: string
+  onChange?: (value: string) => void
+  orientation?: 'vertical' | 'horizontal'
+  disabled?: boolean
+  label?: string
+  name?: string
+  className?: string
+}
+```
+
+- Unlike `Checkbox` (self-contained `checked`/`onChange`), `Radio` is **presentation-only** inside a `RadioGroup` — `checked` is computed and injected by `RadioGroup` (via `cloneElement`, comparing each child's `value` to the group's `value`), and clicks bubble up to the group's `onChange`. A standalone `<Radio>` outside a group can still be used with an explicit `checked` prop for one-off cases, but has no `onChange` of its own — matches Jira's prop list (`value`, `disabled`, `label` only for `Radio`; `value`/`onChange`/`orientation` on `RadioGroup`).
+- `RadioGroup`'s `disabled` cascades to all children (a child's own `disabled={true}` still wins if explicitly set).
+
+### R-05: Accessibility
+
+- `RadioGroup` root: `role="radiogroup"`, `aria-label={label}`.
+- Each `Radio`: `role="radio"`, `aria-checked`, `aria-disabled`, single shared `tabIndex` roving pattern — **only the checked radio (or the first, if none checked) is `tabIndex=0`; all others are `tabIndex=-1`**, matching native `<input type="radio">` group behavior and the Jira requirement ("setas navegam entre opções").
+- Keyboard on the group (`onKeyDown` at the `radiogroup` container, per WAI-ARIA radiogroup pattern): `ArrowDown`/`ArrowRight` → next option (wraps), `ArrowUp`/`ArrowLeft` → previous (wraps), moving focus AND selecting immediately (native radio group convention — arrow keys both move and select, unlike Select's arrow-then-Enter). `Space`/`Enter` on a focused radio also selects (redundant with arrow-select but required by Jira's acceptance criteria).
+- `label` + `id` → `aria-labelledby`, same click-to-toggle span pattern as Checkbox (not native `<label htmlFor>`, same reasoning: root is `role="radio"`, not a form control).
+
+---
+
+## Out of scope (P7)
+
+| Feature | Reason |
+|---|---|
+| Error/invalid state | Not in Figma (same as Checkbox) |
+| Radix UI adoption | Rejected — see Architecture decision |
+| `FormField` wrapper | ID-3175, not yet built |
+| Card-style radio (Figma has a separate "App / Card checkbox" component) | Different component, not requested by ID-3173 |

--- a/.specs/features/p7-radio/tasks.md
+++ b/.specs/features/p7-radio/tasks.md
@@ -1,0 +1,285 @@
+# Radio — Tasks (ID-3173)
+
+**Spec:** `.specs/features/p7-radio/spec.md`
+**Branch:** `feat/ID-3173-radio`
+**Reference:** `src/components/Checkbox/Checkbox.tsx` (row anatomy, custom role-based control, label click pattern)
+
+---
+
+## Task 1 — Branch + Jira setup
+
+- [x] Transition Jira ID-3173 → In Progress (transition id `"3"`)
+- [ ] Create branch: `git checkout -b feat/ID-3173-radio` (from up-to-date `main`, after ID-3172 merge)
+
+---
+
+## Task 2 — Component implementation
+
+**Files:**
+- Create: `src/components/Radio/Radio.tsx`
+- Create: `src/components/Radio/RadioGroup.tsx`
+
+**Radio.tsx** — presentation component, `checked`/`disabled`/`tabIndex` normally injected by `RadioGroup` via `cloneElement`, but usable standalone with explicit `checked`:
+
+```tsx
+import { cn } from '../../utils/cn'
+
+export interface RadioProps {
+  value: string
+  checked?: boolean
+  disabled?: boolean
+  label?: string
+  supportingText?: string
+  size?: 'sm' | 'md'
+  id?: string
+  name?: string
+  tabIndex?: number
+  onSelect?: (value: string) => void
+  className?: string
+}
+
+const BOX_SIZE = {
+  sm: 'size-[16px]',
+  md: 'size-[24px]',
+}
+
+const DOT_SIZE = {
+  sm: 'size-[8px]',
+  md: 'size-[12px]',
+}
+
+export function Radio({
+  value,
+  checked = false,
+  disabled,
+  label,
+  supportingText,
+  size = 'md',
+  id,
+  name,
+  tabIndex = 0,
+  onSelect,
+  className,
+}: RadioProps) {
+  const labelId = label ? `${id}-label` : undefined
+  const descId = supportingText ? `${id}-desc` : undefined
+
+  function select() {
+    if (disabled) return
+    onSelect?.(value)
+  }
+
+  return (
+    <div className={cn('flex items-start gap-[12px]', className)}>
+      <span className="flex items-center justify-center pt-[2px] shrink-0">
+        <span
+          id={id}
+          role="radio"
+          aria-checked={checked}
+          aria-disabled={disabled || undefined}
+          aria-labelledby={labelId}
+          aria-describedby={descId}
+          tabIndex={disabled ? -1 : tabIndex}
+          onClick={select}
+          data-value={value}
+          data-radio-name={name}
+          className={cn(
+            'relative flex items-center justify-center rounded-full border outline-none transition-colors',
+            'focus-visible:ring-2 focus-visible:ring-[#FF5100] focus-visible:ring-offset-2',
+            BOX_SIZE[size],
+            disabled
+              ? 'bg-[#E2E2E2] border-[#CFCFCF] cursor-not-allowed'
+              : checked
+                ? 'bg-[#F7F7F7] border-[#FF5100] hover:shadow-[0px_0px_12px_0px_rgba(255,169,71,0.4)] cursor-pointer'
+                : 'bg-[#F7F7F7] border-[#B6B6B6] hover:border-[#FF5100] hover:shadow-[0px_0px_12px_0px_rgba(255,169,71,0.4)] cursor-pointer',
+          )}
+        >
+          {checked && (
+            <span className={cn('rounded-full', DOT_SIZE[size], disabled ? 'bg-[#CFCFCF]' : 'bg-[#FF5100]')} />
+          )}
+        </span>
+      </span>
+      {(label || supportingText) && (
+        <span className="flex flex-col gap-[2px] flex-1 min-w-0">
+          {label && (
+            <span
+              id={labelId}
+              onClick={select}
+              className={cn(
+                "font-['Funnel_Display'] text-[16px] leading-[24px] text-[#393939] select-none",
+                disabled ? 'cursor-not-allowed' : 'cursor-pointer',
+                checked ? 'font-medium' : 'font-normal',
+              )}
+            >
+              {label}
+            </span>
+          )}
+          {supportingText && (
+            <p
+              id={descId}
+              className="font-['Funnel_Display'] text-[14px] leading-[20px] tracking-[0.1px] text-[#808080]"
+            >
+              {supportingText}
+            </p>
+          )}
+        </span>
+      )}
+    </div>
+  )
+}
+```
+
+**RadioGroup.tsx** — owns `role="radiogroup"`, roving tabindex, arrow-key navigation, injects `checked`/`disabled`/`tabIndex`/`onSelect`/`name`/`id` into each `Radio` child via `cloneElement`:
+
+```tsx
+import { Children, cloneElement, isValidElement, useId, type KeyboardEvent, type ReactElement, type ReactNode } from 'react'
+import type { RadioProps } from './Radio'
+import { cn } from '../../utils/cn'
+
+export interface RadioGroupProps {
+  children: ReactNode
+  value?: string
+  onChange?: (value: string) => void
+  orientation?: 'vertical' | 'horizontal'
+  disabled?: boolean
+  label?: string
+  name?: string
+  className?: string
+}
+
+export function RadioGroup({
+  children,
+  value,
+  onChange,
+  orientation = 'vertical',
+  disabled,
+  label,
+  name,
+  className,
+}: RadioGroupProps) {
+  const groupId = useId()
+  const groupName = name ?? groupId
+
+  const items = Children.toArray(children).filter(isValidElement) as ReactElement<RadioProps>[]
+  const checkedIndex = items.findIndex((item) => item.props.value === value)
+  const activeIndex = checkedIndex >= 0 ? checkedIndex : 0
+
+  function selectByIndex(index: number) {
+    const item = items[index]
+    if (!item || item.props.disabled || disabled) return
+    onChange?.(item.props.value)
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLDivElement>) {
+    if (disabled) return
+    const enabledIndexes = items.map((item, i) => i).filter((i) => !items[i].props.disabled)
+    if (enabledIndexes.length === 0) return
+    const currentPos = enabledIndexes.indexOf(activeIndex)
+
+    if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
+      e.preventDefault()
+      const next = enabledIndexes[(currentPos + 1) % enabledIndexes.length]
+      selectByIndex(next)
+    } else if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
+      e.preventDefault()
+      const prev = enabledIndexes[(currentPos - 1 + enabledIndexes.length) % enabledIndexes.length]
+      selectByIndex(prev)
+    } else if (e.key === ' ' || e.key === 'Enter') {
+      e.preventDefault()
+      selectByIndex(activeIndex)
+    }
+  }
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label={label}
+      onKeyDown={handleKeyDown}
+      className={cn('flex', orientation === 'vertical' ? 'flex-col gap-[12px]' : 'flex-row gap-[24px]', className)}
+    >
+      {items.map((item, index) =>
+        cloneElement(item, {
+          key: item.props.value,
+          id: item.props.id ?? `${groupId}-${item.props.value}`,
+          name: groupName,
+          checked: item.props.value === value,
+          disabled: disabled || item.props.disabled,
+          tabIndex: index === activeIndex ? 0 : -1,
+          onSelect: () => selectByIndex(index),
+        }),
+      )}
+    </div>
+  )
+}
+```
+
+**Notes:**
+- Roving tabindex: only `activeIndex` (checked item, or index 0 if nothing checked) gets `tabIndex=0` — Tab enters/exits the group at one stop, matching native radio group behavior
+- Arrow keys both move focus AND select (per Jira: "setas navegam entre opções... Enter/Space seleciona" — arrow-select is the dominant native radio pattern; Space/Enter is kept too since Jira lists it explicitly, functions as a no-op re-select on the already-focused item)
+- `Radio` remains independently usable outside a group (explicit `checked`, no `onSelect` wiring needed) for edge cases, but `RadioGroup` is the primary documented usage per spec R-04
+- Dot size 50% of box — flagged `[Provável]` in spec.md, not pixel-verified (Figma renders checked radio as a flattened image)
+
+- [ ] Create `src/components/Radio/Radio.tsx` with code above
+- [ ] Create `src/components/Radio/RadioGroup.tsx` with code above
+- [ ] Run `pnpm typecheck` — must pass
+
+---
+
+## Task 3 — Barrel export + library export
+
+- [ ] Create `src/components/Radio/index.ts`:
+  ```ts
+  export { Radio } from './Radio'
+  export type { RadioProps } from './Radio'
+  export { RadioGroup } from './RadioGroup'
+  export type { RadioGroupProps } from './RadioGroup'
+  ```
+- [ ] Add to `src/index.ts` after Checkbox exports:
+  ```ts
+  export { Radio, RadioGroup } from './components/Radio'
+  export type { RadioProps, RadioGroupProps } from './components/Radio'
+  ```
+- [ ] Run `pnpm build` — must produce dist/ without errors
+
+---
+
+## Task 4 — Unit tests
+
+**File:** `src/components/Radio/Radio.test.tsx`
+
+Tests (RadioGroup-driven, since that's the primary use case):
+- renders all radios with `role="radio"` inside `role="radiogroup"`
+- marks the radio matching `value` as `aria-checked=true`, others `false`
+- calls `onChange` with clicked radio's value
+- only active radio (checked, or first if none checked) has `tabIndex=0`; rest `-1`
+- `ArrowDown`/`ArrowRight` selects next enabled radio (wraps at end)
+- `ArrowUp`/`ArrowLeft` selects previous enabled radio (wraps at start)
+- skips disabled radios during arrow navigation
+- `disabled` on `RadioGroup` cascades to all children — clicking any radio does not call `onChange`
+- individual `Radio`'s own `disabled` wins even if group is enabled
+- renders label + supporting text
+- horizontal orientation applies row layout class
+- clicking label text selects the radio
+
+- [ ] Create `src/components/Radio/Radio.test.tsx` with tests above (~12 tests)
+- [ ] Run `pnpm test` — all must pass
+
+---
+
+## Task 5 — Storybook stories
+
+**File:** `src/components/Radio/Radio.stories.tsx`
+
+Stories: `Default` (RadioGroup, 3 options), `WithSupportingText`, `Horizontal`, `Disabled` (whole group), `DisabledOption` (one option only), `Small`, `AllStates`.
+
+- [ ] Create `src/components/Radio/Radio.stories.tsx`
+- [ ] Verify visually (headless screenshot or `pnpm storybook`) against Figma node `3228:15912` Radio column
+
+---
+
+## Task 6 — Commit + finish branch
+
+- [ ] `git add src/components/Radio/ src/index.ts .specs/features/p7-radio/`
+- [ ] `git commit -m "feat(radio): Radio + RadioGroup with roving tabindex, arrow-key navigation, orientations"`
+- [ ] `pnpm lint && pnpm test && pnpm build` — final gate, all pass
+- [ ] Push branch, open PR, add PR link as Jira comment, transition ID-3173 → QA - Testing

--- a/src/components/Radio/Radio.stories.tsx
+++ b/src/components/Radio/Radio.stories.tsx
@@ -1,0 +1,95 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useState } from 'react'
+import { Radio } from './Radio'
+import { RadioGroup } from './RadioGroup'
+
+const meta: Meta<typeof RadioGroup> = {
+  title: 'Components/Radio',
+  component: RadioGroup,
+  tags: ['autodocs'],
+}
+export default meta
+type Story = StoryObj<typeof RadioGroup>
+
+export const Default: Story = {
+  render: () => {
+    const [value, setValue] = useState('basic')
+    return (
+      <RadioGroup label="Plan" value={value} onChange={setValue}>
+        <Radio value="basic" label="Basic" />
+        <Radio value="pro" label="Pro" />
+        <Radio value="enterprise" label="Enterprise" />
+      </RadioGroup>
+    )
+  },
+}
+
+export const WithSupportingText: Story = {
+  render: () => {
+    const [value, setValue] = useState('email')
+    return (
+      <RadioGroup label="Contact method" value={value} onChange={setValue}>
+        <Radio value="email" label="Email" supportingText="We'll send updates to your inbox." />
+        <Radio value="sms" label="SMS" supportingText="Standard messaging rates may apply." />
+      </RadioGroup>
+    )
+  },
+}
+
+export const Horizontal: Story = {
+  render: () => {
+    const [value, setValue] = useState('sm')
+    return (
+      <RadioGroup label="Size" value={value} onChange={setValue} orientation="horizontal">
+        <Radio value="sm" label="Small" />
+        <Radio value="md" label="Medium" />
+        <Radio value="lg" label="Large" />
+      </RadioGroup>
+    )
+  },
+}
+
+export const Disabled: Story = {
+  render: () => (
+    <RadioGroup label="Plan" value="basic" disabled>
+      <Radio value="basic" label="Basic" />
+      <Radio value="pro" label="Pro" />
+    </RadioGroup>
+  ),
+}
+
+export const DisabledOption: Story = {
+  render: () => {
+    const [value, setValue] = useState('basic')
+    return (
+      <RadioGroup label="Plan" value={value} onChange={setValue}>
+        <Radio value="basic" label="Basic" />
+        <Radio value="pro" label="Pro" />
+        <Radio value="enterprise" label="Enterprise (unavailable)" disabled />
+      </RadioGroup>
+    )
+  },
+}
+
+export const Small: Story = {
+  render: () => {
+    const [value, setValue] = useState('basic')
+    return (
+      <RadioGroup label="Plan" value={value} onChange={setValue}>
+        <Radio value="basic" label="Basic" size="sm" />
+        <Radio value="pro" label="Pro" size="sm" />
+      </RadioGroup>
+    )
+  },
+}
+
+export const AllStates: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6 p-4 max-w-sm">
+      <Radio value="unchecked" label="Unchecked" />
+      <Radio value="checked" label="Checked" checked />
+      <Radio value="disabled" label="Disabled" disabled />
+      <Radio value="disabled-checked" label="Disabled checked" checked disabled />
+    </div>
+  ),
+}

--- a/src/components/Radio/Radio.test.tsx
+++ b/src/components/Radio/Radio.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ComponentProps } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { Radio } from './Radio'
+import { RadioGroup } from './RadioGroup'
+
+function renderGroup(props: Partial<ComponentProps<typeof RadioGroup>> = {}) {
+  const handleChange = vi.fn()
+  render(
+    <RadioGroup label="Plan" value="basic" onChange={handleChange} {...props}>
+      <Radio value="basic" label="Basic" />
+      <Radio value="pro" label="Pro" />
+      <Radio value="enterprise" label="Enterprise" disabled />
+    </RadioGroup>,
+  )
+  return { handleChange }
+}
+
+describe('RadioGroup + Radio', () => {
+  it('renders all radios inside role=radiogroup', () => {
+    renderGroup()
+    expect(screen.getByRole('radiogroup', { name: 'Plan' })).toBeInTheDocument()
+    expect(screen.getAllByRole('radio')).toHaveLength(3)
+  })
+
+  it('marks the radio matching value as checked, others unchecked', () => {
+    renderGroup()
+    const radios = screen.getAllByRole('radio')
+    expect(radios[0]).toHaveAttribute('aria-checked', 'true')
+    expect(radios[1]).toHaveAttribute('aria-checked', 'false')
+    expect(radios[2]).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('calls onChange with clicked radio value', async () => {
+    const { handleChange } = renderGroup()
+    await userEvent.click(screen.getByText('Pro'))
+    expect(handleChange).toHaveBeenCalledWith('pro')
+  })
+
+  it('only the checked radio has tabIndex=0, others -1', () => {
+    renderGroup()
+    const radios = screen.getAllByRole('radio')
+    expect(radios[0]).toHaveAttribute('tabIndex', '0')
+    expect(radios[1]).toHaveAttribute('tabIndex', '-1')
+  })
+
+  it('defaults tabIndex=0 to first item when nothing is checked', () => {
+    renderGroup({ value: undefined })
+    const radios = screen.getAllByRole('radio')
+    expect(radios[0]).toHaveAttribute('tabIndex', '0')
+  })
+
+  it('ArrowDown selects next enabled radio', async () => {
+    const { handleChange } = renderGroup()
+    screen.getAllByRole('radio')[0].focus()
+    await userEvent.keyboard('{ArrowDown}')
+    expect(handleChange).toHaveBeenCalledWith('pro')
+  })
+
+  it('ArrowUp wraps to previous enabled radio', async () => {
+    const { handleChange } = renderGroup({ value: 'basic' })
+    screen.getAllByRole('radio')[0].focus()
+    await userEvent.keyboard('{ArrowUp}')
+    // basic is index 0; enabled indexes are [0,1] (enterprise disabled) -> wraps to index 1 (pro)
+    expect(handleChange).toHaveBeenCalledWith('pro')
+  })
+
+  it('skips disabled radios during arrow navigation', async () => {
+    const { handleChange } = renderGroup({ value: 'pro' })
+    screen.getAllByRole('radio')[1].focus()
+    await userEvent.keyboard('{ArrowDown}')
+    // pro (index1) -> next enabled wraps back to basic (index0), never lands on disabled enterprise
+    expect(handleChange).toHaveBeenCalledWith('basic')
+  })
+
+  it('does not call onChange when RadioGroup disabled', async () => {
+    const { handleChange } = renderGroup({ disabled: true })
+    await userEvent.click(screen.getByText('Pro'))
+    expect(handleChange).not.toHaveBeenCalled()
+  })
+
+  it('individual disabled radio ignores clicks even if group enabled', async () => {
+    const { handleChange } = renderGroup()
+    await userEvent.click(screen.getByText('Enterprise'))
+    expect(handleChange).not.toHaveBeenCalled()
+  })
+
+  it('renders supporting text', () => {
+    render(
+      <RadioGroup value="a" onChange={vi.fn()}>
+        <Radio value="a" label="Option A" supportingText="Helper text" />
+      </RadioGroup>,
+    )
+    expect(screen.getByText('Helper text')).toBeInTheDocument()
+  })
+
+  it('applies horizontal orientation layout', () => {
+    const { container } = render(
+      <RadioGroup value="a" onChange={vi.fn()} orientation="horizontal">
+        <Radio value="a" label="A" />
+        <Radio value="b" label="B" />
+      </RadioGroup>,
+    )
+    expect(container.querySelector('[role="radiogroup"]')).toHaveClass('flex-row')
+  })
+})

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -1,0 +1,105 @@
+import { cn } from '../../utils/cn'
+
+export interface RadioProps {
+  value: string
+  checked?: boolean
+  disabled?: boolean
+  label?: string
+  supportingText?: string
+  size?: 'sm' | 'md'
+  id?: string
+  name?: string
+  tabIndex?: number
+  onSelect?: (value: string) => void
+  className?: string
+}
+
+const BOX_SIZE = {
+  sm: 'size-[16px]',
+  md: 'size-[24px]',
+}
+
+const DOT_SIZE = {
+  sm: 'size-[8px]',
+  md: 'size-[12px]',
+}
+
+export function Radio({
+  value,
+  checked = false,
+  disabled,
+  label,
+  supportingText,
+  size = 'md',
+  id,
+  name,
+  tabIndex = 0,
+  onSelect,
+  className,
+}: RadioProps) {
+  const labelId = label ? `${id}-label` : undefined
+  const descId = supportingText ? `${id}-desc` : undefined
+
+  function select() {
+    if (disabled) return
+    onSelect?.(value)
+  }
+
+  return (
+    <div className={cn('flex items-start gap-[12px]', className)}>
+      <span className="flex items-center justify-center pt-[2px] shrink-0">
+        <span
+          id={id}
+          role="radio"
+          aria-checked={checked}
+          aria-disabled={disabled || undefined}
+          aria-labelledby={labelId}
+          aria-describedby={descId}
+          tabIndex={disabled ? -1 : tabIndex}
+          onClick={select}
+          data-value={value}
+          data-radio-name={name}
+          className={cn(
+            'relative flex items-center justify-center rounded-full border outline-none transition-colors',
+            'focus-visible:ring-2 focus-visible:ring-[#FF5100] focus-visible:ring-offset-2',
+            BOX_SIZE[size],
+            disabled
+              ? 'bg-[#E2E2E2] border-[#CFCFCF] cursor-not-allowed'
+              : checked
+                ? 'bg-[#F7F7F7] border-[#FF5100] hover:shadow-[0px_0px_12px_0px_rgba(255,169,71,0.4)] cursor-pointer'
+                : 'bg-[#F7F7F7] border-[#B6B6B6] hover:border-[#FF5100] hover:shadow-[0px_0px_12px_0px_rgba(255,169,71,0.4)] cursor-pointer',
+          )}
+        >
+          {checked && (
+            <span className={cn('rounded-full', DOT_SIZE[size], disabled ? 'bg-[#CFCFCF]' : 'bg-[#FF5100]')} />
+          )}
+        </span>
+      </span>
+      {(label || supportingText) && (
+        <span className="flex flex-col gap-[2px] flex-1 min-w-0">
+          {label && (
+            <span
+              id={labelId}
+              onClick={select}
+              className={cn(
+                "font-['Funnel_Display'] text-[16px] leading-[24px] text-[#393939] select-none",
+                disabled ? 'cursor-not-allowed' : 'cursor-pointer',
+                checked ? 'font-medium' : 'font-normal',
+              )}
+            >
+              {label}
+            </span>
+          )}
+          {supportingText && (
+            <p
+              id={descId}
+              className="font-['Funnel_Display'] text-[14px] leading-[20px] tracking-[0.1px] text-[#808080]"
+            >
+              {supportingText}
+            </p>
+          )}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/src/components/Radio/RadioGroup.tsx
+++ b/src/components/Radio/RadioGroup.tsx
@@ -1,0 +1,87 @@
+import {
+  Children,
+  cloneElement,
+  isValidElement,
+  useId,
+  type KeyboardEvent,
+  type ReactElement,
+  type ReactNode,
+} from 'react'
+import type { RadioProps } from './Radio'
+import { cn } from '../../utils/cn'
+
+export interface RadioGroupProps {
+  children: ReactNode
+  value?: string
+  onChange?: (value: string) => void
+  orientation?: 'vertical' | 'horizontal'
+  disabled?: boolean
+  label?: string
+  name?: string
+  className?: string
+}
+
+export function RadioGroup({
+  children,
+  value,
+  onChange,
+  orientation = 'vertical',
+  disabled,
+  label,
+  name,
+  className,
+}: RadioGroupProps) {
+  const groupId = useId()
+  const groupName = name ?? groupId
+
+  const items = Children.toArray(children).filter(isValidElement) as ReactElement<RadioProps>[]
+  const checkedIndex = items.findIndex((item) => item.props.value === value)
+  const activeIndex = checkedIndex >= 0 ? checkedIndex : 0
+
+  function selectByIndex(index: number) {
+    const item = items[index]
+    if (!item || item.props.disabled || disabled) return
+    onChange?.(item.props.value)
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLDivElement>) {
+    if (disabled) return
+    const enabledIndexes = items.map((_, i) => i).filter((i) => !items[i].props.disabled)
+    if (enabledIndexes.length === 0) return
+    const currentPos = enabledIndexes.indexOf(activeIndex)
+
+    if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
+      e.preventDefault()
+      const next = enabledIndexes[(currentPos + 1) % enabledIndexes.length]
+      selectByIndex(next)
+    } else if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
+      e.preventDefault()
+      const prev = enabledIndexes[(currentPos - 1 + enabledIndexes.length) % enabledIndexes.length]
+      selectByIndex(prev)
+    } else if (e.key === ' ' || e.key === 'Enter') {
+      e.preventDefault()
+      selectByIndex(activeIndex)
+    }
+  }
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label={label}
+      onKeyDown={handleKeyDown}
+      className={cn('flex', orientation === 'vertical' ? 'flex-col gap-[12px]' : 'flex-row gap-[24px]', className)}
+    >
+      {items.map((item, index) =>
+        cloneElement(item, {
+          key: item.props.value,
+          id: item.props.id ?? `${groupId}-${item.props.value}`,
+          name: groupName,
+          checked: item.props.value === value,
+          disabled: disabled || item.props.disabled,
+          tabIndex: index === activeIndex ? 0 : -1,
+          onSelect: () => selectByIndex(index),
+        }),
+      )}
+    </div>
+  )
+}

--- a/src/components/Radio/index.ts
+++ b/src/components/Radio/index.ts
@@ -1,0 +1,4 @@
+export { Radio } from './Radio'
+export type { RadioProps } from './Radio'
+export { RadioGroup } from './RadioGroup'
+export type { RadioGroupProps } from './RadioGroup'

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,9 @@ export type { SelectProps, SelectOption } from './components/Select'
 export { Checkbox, CheckboxGroup } from './components/Checkbox'
 export type { CheckboxProps, CheckboxGroupProps } from './components/Checkbox'
 
+export { Radio, RadioGroup } from './components/Radio'
+export type { RadioProps, RadioGroupProps } from './components/Radio'
+
 // Design tokens
 export { colors } from './tokens/colors'
 export type { Colors } from './tokens/colors'


### PR DESCRIPTION
## Summary
- Adds `Radio` + `RadioGroup` to `@starbemtech/react-starsystem` (P7, Jira ID-3173)
- Custom implementation (not Radix UI) — same architecture decision as `Checkbox` (#7), kept consistent with the rest of the library
- States: unchecked/checked/disabled, sizes sm(16px)/md(24px) — ring/background colors Figma-verified against Star System "Checkboxes" page Radio variants (node `3228:15912`). Inner dot size (~50% of box) is a documented `[Provável]` inference — Figma renders the checked radio as a flattened image, not exposing separate layers
- `role="radiogroup"` + roving `tabIndex` (only checked/first item is tabbable) + arrow-key navigation (Up/Left, Down/Right, wraps, skips disabled) + Space/Enter — matches Jira's keyboard requirement
- `RadioGroup.disabled` cascades to children; a child's own `disabled` still wins
- `Radio` also usable standalone with explicit `checked` outside a group

## Test plan
- [x] `pnpm typecheck` — pass
- [x] `pnpm lint` — pass
- [x] `pnpm test` — 101/101 pass (12 new Radio/RadioGroup tests)
- [x] `pnpm build` — pass
- [x] Storybook stories visually verified via headless screenshot — caught and fixed a story bug (`AllStates` wrapped a standalone-`checked` `Radio` inside a valueless `RadioGroup`, which overrides `checked` via `cloneElement` — confirms `RadioGroup` always owns `checked` for its children, as specced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)