### PR TITLE
feat(toggle): Toggle switch component

### DIFF
--- a/.specs/features/p8-toggle/spec.md
+++ b/.specs/features/p8-toggle/spec.md
@@ -1,0 +1,93 @@
+# Toggle Component Spec — P8
+
+**Jira:** ID-3174
+**Figma:** Star System → "Toogle" page (fileKey: `6wfkhBhONJ7r4A0PZWIsIs`, nodeId: `3228:12955`)
+**Branch:** `feat/ID-3174-toggle`
+
+**Architecture decision:** Custom, not Radix UI — same decision/rationale as Checkbox and Radio (see `.specs/features/p6-checkbox/spec.md`).
+
+---
+
+## Figma-Verified Nodes
+
+| Node | Description |
+|---|---|
+| `3228:13517` | Toggle, md, off, Default (bare, 44×24) |
+| `3228:13437` | Toggle, md, on, Default |
+| `3228:13537` | Toggle, md, off, Disabled |
+| `3228:13457` | Toggle, md, on, Disabled |
+| `3228:13527` | Toggle, sm, off, Default (bare, 36×20) |
+| `3228:13447` | Toggle, sm, on, Default |
+| `3228:13522` | Toggle + label + supporting text, md, off, Default (344px row anatomy) |
+
+No Hover variant exists in Figma for Toggle (unlike Checkbox/Radio, which have an explicit glow-on-hover state) — not implemented, to avoid inventing a state.
+
+## Requirements
+
+### R-01: Track & thumb anatomy
+
+| Size | Track | Thumb | Thumb travel (off→on) |
+|---|---|---|---|
+| `sm` | 36×20px, `rounded-full`, `p-[2px]` | 16×16px | 16px |
+| `md` (default) | 44×24px, `rounded-full`, `p-[2px]` | 20×20px | 20px |
+
+Thumb: `bg-[#F7F7F7]` (Neutral/25) always, with shadow `0px_1px_2px_0px_rgba(16,24,40,0.06),0px_1px_3px_0px_rgba(16,24,40,0.10)` (Figma `Shadow/sm`, both states). Travel distance = track width − thumb size − 2×padding (e.g. md: 44−20−4=20), same math as shadcn's Switch — cross-checked, not coincidence.
+
+### R-02: States & colors (Figma-verified)
+
+| State | Track background | Thumb |
+|---|---|---|
+| Off, Default | `#E2E2E2` (Neutral/100) | `#F7F7F7` + shadow |
+| **On, Default** | **`#461FAE` (Secondary/Darker — purple, NOT Primary/Base orange)** | `#F7F7F7` + shadow |
+| Off, Disabled | `#E2E2E2` | `#EFEFEF` (Neutral/50) muted, `opacity-50` on whole control |
+| On, Disabled | `#461FAE` (same hex Figma reports for both default/disabled — muting is via layer opacity in Figma, not a distinct color) | `#F7F7F7`, `opacity-50` on whole control |
+
+> **Important, don't "fix" this to match Checkbox/Radio:** Toggle's "on" color is genuinely purple (`#461FAE`), verified twice (bare node + labeled row node both report `Secondary/Darker: #461FAE`, no orange token anywhere in the on-state response). This is a deliberate Figma distinction between binary settings toggles (purple) and selection controls (orange checkmarks/radios).
+
+### R-03: Label + supporting text anatomy (Figma-verified, differs from Checkbox/Radio)
+
+| Property | Value |
+|---|---|
+| Row layout | `flex items-start gap-[12px]` (no `pt-[2px]` wrapper — track is vertically centered differently since it has no top-aligned checkbox-style icon) |
+| Label | Funnel Display, **Medium (500) always** — 16px/24px, `#4D4D4D` (Neutral/700) |
+| Supporting text | Funnel Display, Regular, 16px/24px (not 14px like Checkbox/Radio's supporting text — Figma's Toggle row uses the same 16px size for both lines), `#808080` (Neutral/500) |
+| Gap label↔supporting | `2px` |
+
+> Two deliberate divergences from Checkbox/Radio, both Figma-verified: (1) label color is Neutral/700 `#4D4D4D`, not Neutral/800 `#393939`; (2) label weight is always Medium, it does NOT switch Regular↔Medium based on checked state (Checkbox/Radio's "emphasize when active" convention does not apply here — the fetched Pressed=False anatomy example already renders `Funnel_Display:Medium`).
+
+### R-04: Props API
+
+```ts
+export interface ToggleProps {
+  checked?: boolean
+  disabled?: boolean
+  onChange?: (checked: boolean) => void
+  label?: string
+  supportingText?: string
+  size?: 'sm' | 'md'
+  id?: string
+  name?: string
+  className?: string
+}
+```
+
+Self-contained like `Checkbox` (not group-owned like `Radio`) — matches Jira's prop list (`checked`, `disabled`, `onChange`, `label`, `size` directly on `Toggle`, no separate group component requested).
+
+### R-05: Accessibility
+
+- `role="switch"`, `aria-checked`, `aria-disabled`, `tabIndex={disabled ? -1 : 0}`.
+- `Space`/`Enter` toggles (per Jira "Label clicavel alterna estado" + native switch keyboard convention — switches don't use arrow keys, that's Radio's pattern).
+- Clicking the label text toggles too (same `<span onClick>` pattern as Checkbox — root is `role="switch"`, not a native form control, so no `htmlFor`).
+- `transition-colors` on track (background) + `transition-transform` on thumb (translateX) for the on/off animation Jira requires.
+- Focus-visible ring: same orange WCAG ring convention as Button/Input/Checkbox/Radio (`focus-visible:ring-2 ring-[#FF5100] ring-offset-2`) — Figma has no distinct focus token for Toggle, reusing the established library-wide convention is the safer default over inventing one.
+
+---
+
+## Out of scope (P8)
+
+| Feature | Reason |
+|---|---|
+| Hover state | Not in Figma for Toggle (present for Checkbox/Radio, absent here — verified via metadata, not an oversight) |
+| Error/invalid state | Not in Figma (same as Checkbox/Radio) |
+| Radix UI adoption | Rejected — see Architecture decision |
+| `FormField` wrapper | ID-3175, not yet built |

--- a/.specs/features/p8-toggle/tasks.md
+++ b/.specs/features/p8-toggle/tasks.md
@@ -1,0 +1,201 @@
+# Toggle — Tasks (ID-3174)
+
+**Spec:** `.specs/features/p8-toggle/spec.md`
+**Branch:** `feat/ID-3174-toggle`
+**Reference:** `src/components/Checkbox/Checkbox.tsx` (self-contained checked/onChange, label click pattern)
+
+---
+
+## Task 1 — Branch + Jira setup
+
+- [x] Transition Jira ID-3174 → In Progress (transition id `"3"`)
+- [ ] Create branch: `git checkout -b feat/ID-3174-toggle` (from up-to-date `main`)
+
+---
+
+## Task 2 — Component implementation
+
+**File:** `src/components/Toggle/Toggle.tsx`
+
+```tsx
+import { type KeyboardEvent } from 'react'
+import { cn } from '../../utils/cn'
+
+export interface ToggleProps {
+  checked?: boolean
+  disabled?: boolean
+  onChange?: (checked: boolean) => void
+  label?: string
+  supportingText?: string
+  size?: 'sm' | 'md'
+  id?: string
+  name?: string
+  className?: string
+}
+
+const TRACK_SIZE = {
+  sm: 'w-[36px] h-[20px]',
+  md: 'w-[44px] h-[24px]',
+}
+
+const THUMB_SIZE = {
+  sm: 'size-[16px]',
+  md: 'size-[20px]',
+}
+
+const THUMB_TRAVEL = {
+  sm: 'translate-x-[16px]',
+  md: 'translate-x-[20px]',
+}
+
+const THUMB_SHADOW = 'shadow-[0px_1px_2px_0px_rgba(16,24,40,0.06),0px_1px_3px_0px_rgba(16,24,40,0.10)]'
+
+export function Toggle({
+  checked = false,
+  disabled,
+  onChange,
+  label,
+  supportingText,
+  size = 'md',
+  id,
+  name,
+  className,
+}: ToggleProps) {
+  const labelId = label ? `${id}-label` : undefined
+  const descId = supportingText ? `${id}-desc` : undefined
+
+  function toggle() {
+    if (disabled) return
+    onChange?.(!checked)
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLSpanElement>) {
+    if (disabled) return
+    if (e.key === ' ' || e.key === 'Enter') {
+      e.preventDefault()
+      toggle()
+    }
+  }
+
+  return (
+    <div className={cn('flex items-start gap-[12px]', disabled && 'opacity-50', className)}>
+      <span
+        id={id}
+        role="switch"
+        aria-checked={checked}
+        aria-disabled={disabled || undefined}
+        aria-labelledby={labelId}
+        aria-describedby={descId}
+        tabIndex={disabled ? -1 : 0}
+        onClick={toggle}
+        onKeyDown={handleKeyDown}
+        className={cn(
+          'relative flex items-center rounded-full p-[2px] outline-none transition-colors shrink-0',
+          'focus-visible:ring-2 focus-visible:ring-[#FF5100] focus-visible:ring-offset-2',
+          TRACK_SIZE[size],
+          disabled ? 'cursor-not-allowed' : 'cursor-pointer',
+          checked ? 'bg-[#461FAE]' : 'bg-[#E2E2E2]',
+        )}
+      >
+        <span
+          className={cn(
+            'rounded-full bg-[#F7F7F7] transition-transform',
+            THUMB_SIZE[size],
+            THUMB_SHADOW,
+            checked && THUMB_TRAVEL[size],
+          )}
+        />
+      </span>
+      {name && <input type="checkbox" name={name} checked={checked} readOnly className="hidden" />}
+      {(label || supportingText) && (
+        <span className="flex flex-col gap-[2px] flex-1 min-w-0">
+          {label && (
+            <span
+              id={labelId}
+              onClick={toggle}
+              className={cn(
+                "font-['Funnel_Display'] font-medium text-[16px] leading-[24px] text-[#4D4D4D] select-none",
+                disabled ? 'cursor-not-allowed' : 'cursor-pointer',
+              )}
+            >
+              {label}
+            </span>
+          )}
+          {supportingText && (
+            <p id={descId} className="font-['Funnel_Display'] text-[16px] leading-[24px] text-[#808080]">
+              {supportingText}
+            </p>
+          )}
+        </span>
+      )}
+    </div>
+  )
+}
+```
+
+**Notes:**
+- `role="switch"` is the WAI-ARIA-correct role for this pattern (not `role="checkbox"`)
+- Label color `#4D4D4D` and always-Medium weight are Figma-verified divergences from Checkbox/Radio — do NOT "fix" to match them (see spec.md R-03)
+- No hover glow — genuinely absent in Figma for Toggle (see spec.md Out of scope)
+- `disabled` applies `opacity-50` to the whole row (track+thumb+label+supporting), matching Button's established disabled convention in this library, since Figma's disabled thumb/track hex values are the same as default (muting is via Figma layer opacity, not distinct colors)
+
+- [ ] Create `src/components/Toggle/Toggle.tsx` with code above
+- [ ] Run `pnpm typecheck` — must pass
+
+---
+
+## Task 3 — Barrel export + library export
+
+- [ ] Create `src/components/Toggle/index.ts`:
+  ```ts
+  export { Toggle } from './Toggle'
+  export type { ToggleProps } from './Toggle'
+  ```
+- [ ] Add to `src/index.ts` after Radio exports:
+  ```ts
+  export { Toggle } from './components/Toggle'
+  export type { ToggleProps } from './components/Toggle'
+  ```
+- [ ] Run `pnpm build` — must produce dist/ without errors
+
+---
+
+## Task 4 — Unit tests
+
+**File:** `src/components/Toggle/Toggle.test.tsx`
+
+Tests (mirror Checkbox's test shape, adapted for `role="switch"`):
+- renders `aria-checked=false` by default
+- renders `aria-checked=true` when `checked`
+- calls `onChange` with toggled value on click
+- calls `onChange` when clicking label text
+- toggles with Space key
+- toggles with Enter key
+- does not call `onChange` when disabled
+- sets `aria-disabled` when disabled
+- not focusable (`tabIndex=-1`) when disabled
+- renders supporting text when provided
+- associates label via `aria-labelledby`
+
+- [ ] Create `src/components/Toggle/Toggle.test.tsx` with ~11 tests above
+- [ ] Run `pnpm test` — all must pass
+
+---
+
+## Task 5 — Storybook stories
+
+**File:** `src/components/Toggle/Toggle.stories.tsx`
+
+Stories: `Default`, `Checked`, `WithSupportingText`, `Disabled`, `DisabledChecked`, `Small`, `AllStates`.
+
+- [ ] Create `src/components/Toggle/Toggle.stories.tsx`
+- [ ] Verify visually (headless screenshot) against Figma node `3228:12955` — confirm purple `#461FAE` on-track color, NOT orange
+
+---
+
+## Task 6 — Commit + finish branch
+
+- [ ] `git add src/components/Toggle/ src/index.ts .specs/features/p8-toggle/`
+- [ ] `git commit -m "feat(toggle): Toggle switch with sizes, disabled, purple on-state per Figma"`
+- [ ] `pnpm lint && pnpm test && pnpm build` — final gate, all pass
+- [ ] Push branch, open PR, add PR link as Jira comment, transition ID-3174 → QA - Testing

--- a/src/components/Toggle/Toggle.stories.tsx
+++ b/src/components/Toggle/Toggle.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useState } from 'react'
+import { Toggle } from './Toggle'
+
+const meta: Meta<typeof Toggle> = {
+  title: 'Components/Toggle',
+  component: Toggle,
+  tags: ['autodocs'],
+  args: { label: 'Notifications' },
+}
+export default meta
+type Story = StoryObj<typeof Toggle>
+
+export const Default: Story = {
+  render: (args) => {
+    const [checked, setChecked] = useState(false)
+    return <Toggle {...args} checked={checked} onChange={setChecked} />
+  },
+}
+
+export const Checked: Story = {
+  render: (args) => {
+    const [checked, setChecked] = useState(true)
+    return <Toggle {...args} checked={checked} onChange={setChecked} />
+  },
+}
+
+export const WithSupportingText: Story = {
+  render: (args) => {
+    const [checked, setChecked] = useState(false)
+    return <Toggle {...args} checked={checked} onChange={setChecked} supportingText="Get notified about updates." />
+  },
+}
+
+export const Disabled: Story = {
+  args: { disabled: true },
+}
+
+export const DisabledChecked: Story = {
+  args: { disabled: true, checked: true },
+}
+
+export const Small: Story = {
+  args: { size: 'sm' },
+}
+
+export const AllStates: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6 p-4 max-w-sm">
+      <Toggle label="Off" />
+      <Toggle label="On" checked />
+      <Toggle label="Disabled" disabled />
+      <Toggle label="Disabled on" checked disabled />
+      <Toggle label="Small off" size="sm" />
+      <Toggle label="Small on" size="sm" checked />
+    </div>
+  ),
+}

--- a/src/components/Toggle/Toggle.test.tsx
+++ b/src/components/Toggle/Toggle.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { Toggle } from './Toggle'
+
+describe('Toggle', () => {
+  it('renders unchecked by default', () => {
+    render(<Toggle label="Notifications" />)
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('renders checked when checked=true', () => {
+    render(<Toggle label="Notifications" checked />)
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('calls onChange with toggled value on click', async () => {
+    const handleChange = vi.fn()
+    render(<Toggle label="Notifications" checked={false} onChange={handleChange} />)
+    await userEvent.click(screen.getByRole('switch'))
+    expect(handleChange).toHaveBeenCalledWith(true)
+  })
+
+  it('calls onChange when clicking the label text', async () => {
+    const handleChange = vi.fn()
+    render(<Toggle label="Notifications" checked={false} onChange={handleChange} />)
+    await userEvent.click(screen.getByText('Notifications'))
+    expect(handleChange).toHaveBeenCalledWith(true)
+  })
+
+  it('toggles with Space key', async () => {
+    const handleChange = vi.fn()
+    render(<Toggle label="Notifications" checked={false} onChange={handleChange} />)
+    screen.getByRole('switch').focus()
+    await userEvent.keyboard(' ')
+    expect(handleChange).toHaveBeenCalledWith(true)
+  })
+
+  it('toggles with Enter key', async () => {
+    const handleChange = vi.fn()
+    render(<Toggle label="Notifications" checked={false} onChange={handleChange} />)
+    screen.getByRole('switch').focus()
+    await userEvent.keyboard('{Enter}')
+    expect(handleChange).toHaveBeenCalledWith(true)
+  })
+
+  it('does not call onChange when disabled', async () => {
+    const handleChange = vi.fn()
+    render(<Toggle label="Notifications" disabled onChange={handleChange} />)
+    await userEvent.click(screen.getByRole('switch'))
+    expect(handleChange).not.toHaveBeenCalled()
+  })
+
+  it('sets aria-disabled when disabled', () => {
+    render(<Toggle label="Notifications" disabled />)
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-disabled', 'true')
+  })
+
+  it('is not focusable when disabled', () => {
+    render(<Toggle label="Notifications" disabled />)
+    expect(screen.getByRole('switch')).toHaveAttribute('tabIndex', '-1')
+  })
+
+  it('renders supporting text when provided', () => {
+    render(<Toggle label="Notifications" supportingText="Get notified about updates." />)
+    expect(screen.getByText('Get notified about updates.')).toBeInTheDocument()
+  })
+
+  it('associates label via aria-labelledby', () => {
+    render(<Toggle id="notif" label="Notifications" />)
+    const toggle = screen.getByRole('switch')
+    const labelId = toggle.getAttribute('aria-labelledby')
+    expect(labelId).toBeTruthy()
+    expect(document.getElementById(labelId!)).toHaveTextContent('Notifications')
+  })
+})

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -1,0 +1,113 @@
+import { type KeyboardEvent } from 'react'
+import { cn } from '../../utils/cn'
+
+export interface ToggleProps {
+  checked?: boolean
+  disabled?: boolean
+  onChange?: (checked: boolean) => void
+  label?: string
+  supportingText?: string
+  size?: 'sm' | 'md'
+  id?: string
+  name?: string
+  className?: string
+}
+
+const TRACK_SIZE = {
+  sm: 'w-[36px] h-[20px]',
+  md: 'w-[44px] h-[24px]',
+}
+
+const THUMB_SIZE = {
+  sm: 'size-[16px]',
+  md: 'size-[20px]',
+}
+
+const THUMB_TRAVEL = {
+  sm: 'translate-x-[16px]',
+  md: 'translate-x-[20px]',
+}
+
+const THUMB_SHADOW = 'shadow-[0px_1px_2px_0px_rgba(16,24,40,0.06),0px_1px_3px_0px_rgba(16,24,40,0.10)]'
+
+export function Toggle({
+  checked = false,
+  disabled,
+  onChange,
+  label,
+  supportingText,
+  size = 'md',
+  id,
+  name,
+  className,
+}: ToggleProps) {
+  const labelId = label ? `${id}-label` : undefined
+  const descId = supportingText ? `${id}-desc` : undefined
+
+  function toggle() {
+    if (disabled) return
+    onChange?.(!checked)
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLSpanElement>) {
+    if (disabled) return
+    if (e.key === ' ' || e.key === 'Enter') {
+      e.preventDefault()
+      toggle()
+    }
+  }
+
+  return (
+    <div className={cn('flex items-start gap-[12px]', disabled && 'opacity-50', className)}>
+      <span
+        id={id}
+        role="switch"
+        aria-checked={checked}
+        aria-disabled={disabled || undefined}
+        aria-labelledby={labelId}
+        aria-describedby={descId}
+        tabIndex={disabled ? -1 : 0}
+        onClick={toggle}
+        onKeyDown={handleKeyDown}
+        className={cn(
+          'relative flex items-center rounded-full p-[2px] outline-none transition-colors shrink-0',
+          'focus-visible:ring-2 focus-visible:ring-[#FF5100] focus-visible:ring-offset-2',
+          TRACK_SIZE[size],
+          disabled ? 'cursor-not-allowed' : 'cursor-pointer',
+          checked ? 'bg-[#461FAE]' : 'bg-[#E2E2E2]',
+        )}
+      >
+        <span
+          className={cn(
+            'rounded-full bg-[#F7F7F7] transition-transform',
+            THUMB_SIZE[size],
+            THUMB_SHADOW,
+            checked && THUMB_TRAVEL[size],
+          )}
+        />
+      </span>
+      {name && <input type="checkbox" name={name} checked={checked} readOnly className="hidden" />}
+      {(label || supportingText) && (
+        <span className="flex flex-col gap-[2px] flex-1 min-w-0">
+          {label && (
+            <span
+              id={labelId}
+              onClick={toggle}
+              className={cn(
+                "font-['Funnel_Display'] font-medium text-[16px] leading-[24px] text-[#4D4D4D] select-none",
+                disabled ? 'cursor-not-allowed' : 'cursor-pointer',
+              )}
+            >
+              {label}
+            </span>
+          )}
+          {supportingText && (
+            <p id={descId} className="font-['Funnel_Display'] text-[16px] leading-[24px] text-[#808080]">
+              {supportingText}
+            </p>
+          )}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/src/components/Toggle/index.ts
+++ b/src/components/Toggle/index.ts
@@ -1,0 +1,2 @@
+export { Toggle } from './Toggle'
+export type { ToggleProps } from './Toggle'

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,9 @@ export type { CheckboxProps, CheckboxGroupProps } from './components/Checkbox'
 export { Radio, RadioGroup } from './components/Radio'
 export type { RadioProps, RadioGroupProps } from './components/Radio'
 
+export { Toggle } from './components/Toggle'
+export type { ToggleProps } from './components/Toggle'
+
 // Design tokens
 export { colors } from './tokens/colors'
 export type { Colors } from './tokens/colors'


### PR DESCRIPTION
## Summary
- Adds `Toggle` to `@starbemtech/react-starsystem` (P8, Jira ID-3174)
- Custom implementation (not Radix UI) — same architecture decision as Checkbox/Radio (#7, #8)
- `role="switch"`, sizes sm(36×20)/md(44×24), Space/Enter + click toggles, label click toggles
- **Notable Figma finding:** the "on" track color is purple `#461FAE` (Secondary/Darker), not the orange used by Checkbox/Radio — verified twice against Figma node `3228:12955`, documented explicitly in spec.md so it isn't "corrected" to orange in a future pass
- No hover state — genuinely absent in Figma for this component (present for Checkbox/Radio), not an oversight
- Label uses Neutral/700 `#4D4D4D` always-Medium weight — differs from Checkbox/Radio's Regular↔Medium-on-active convention, also Figma-verified

## Test plan
- [x] `pnpm typecheck` — pass
- [x] `pnpm lint` — pass
- [x] `pnpm test` — 112/112 pass (11 new Toggle tests)
- [x] `pnpm build` — pass
- [x] Storybook stories visually verified via headless screenshot — confirms purple on-track, thumb shadow/travel distance, disabled opacity

🤖 Generated with [Claude Code](https://claude.com/claude-code)